### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,2 @@
 .DS_Store
 index.html
-boilerplate
-submodules


### PR DESCRIPTION
Removed boilerplace and submodules from .gitignore, per Vinod.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
