### PR TITLE
Removed "(WAF)" from title, per AWS style

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Citrix Web App Firewall (WAF) on the AWS Cloud—Quick Start
+## Citrix Web App Firewall on the AWS Cloud—Quick Start
 
 For architectural details, step-by-step instructions, and customization options, see the [deployment guide](https://fwd.aws/k7Xk9).
 

--- a/docs/partner_editable/_settings.adoc
+++ b/docs/partner_editable/_settings.adoc
@@ -1,5 +1,5 @@
 :quickstart-project-name: quickstart-citrix-adc-waf
-:partner-product-name: Citrix Web App Firewall (WAF)
+:partner-product-name: Citrix Web App Firewall
 :partner-product-short-name: Citrix WAF
 :partner-company-name: Citrix Systems, Inc.
 :doc-month: August


### PR DESCRIPTION
Daniel reminded me today that, per AWS style, we don't put acronyms in parentheses in titles.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
