### PR TITLE
Doc edits to sync with latest boilerplate

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,10 +1,10 @@
 [submodule "submodules/quickstart-aws-vpc"]
 	path = submodules/quickstart-aws-vpc
-	url = git@github.com:aws-quickstart/quickstart-aws-vpc
+	url = https://github.com/aws-quickstart/quickstart-aws-vpc
 	branch = main
 [submodule "submodules/quickstart-linux-bastion"]
 	path = submodules/quickstart-linux-bastion
-	url = git@github.com:aws-quickstart/quickstart-linux-bastion
+	url = https://github.com/aws-quickstart/quickstart-linux-bastion
 	branch = main
 [submodule "docs/boilerplate"]
 	path = docs/boilerplate

--- a/docs/partner_editable/_settings.adoc
+++ b/docs/partner_editable/_settings.adoc
@@ -8,6 +8,7 @@
 :quickstart-contributors: AWS Quick Start team
 :deployment_time: 15 minutes
 :default_deployment_region: us-east-2
+:parameters_as_appendix:
 // Uncomment these two attributes if you are leveraging
 // - an AWS Marketplace listing.
 // Additional content will be auto-generated based on these attributes.

--- a/docs/partner_editable/deploy_steps.adoc
+++ b/docs/partner_editable/deploy_steps.adoc
@@ -1,5 +1,5 @@
 // We need to work around Step numbers here if we are going to potentially exclude the AMI subscription
-=== Sign in to your AWS account
+=== Confirm your AWS account configuration
 
 . Sign in to your AWS account at https://aws.amazon.com with an IAM user role that has the necessary permissions. For details, see link:#_planning_the_deployment[Planning the deployment] earlier in this guide.
 . Use the Region selector in the navigation bar to choose the AWS Region where you want to deploy high availability across AWS Availability Zones.
@@ -22,31 +22,21 @@ endif::marketplace_subscription[]
 
 === Launch the Quick Start
 
-NOTE: You are responsible for the cost of the AWS services used while running this Quick Start reference deployment. There is no additional cost for using this Quick Start. For full details, see the pricing pages for each AWS service used by this Quick Start. Prices are subject to change.
-
-. Sign in to your AWS account, and choose one of the following options to launch the AWS CloudFormation template. For help with choosing an option, see link:#_deployment_options[deployment options] earlier in this guide.
-
-[cols=",]
-|===
-|https://fwd.aws/nb3Px[Deploy {partner-product-short-name} into a new VPC on AWS^]
-|https://fwd.aws/WVQYn[Deploy {partner-product-short-name} into an existing VPC on AWS^]
-|===
-
 WARNING: If you’re deploying {partner-product-short-name} into an existing VPC, make sure that your VPC has two private subnets in different Availability Zones for the workload instances, and that the subnets aren’t shared. This Quick Start doesn’t support https://docs.aws.amazon.com/vpc/latest/userguide/vpc-sharing.html[shared subnets^]. These subnets require https://docs.aws.amazon.com/vpc/latest/userguide/vpc-nat-gateway.html[NAT gateways^] in their route tables, to allow the instances to download packages and software without exposing them to the internet.
 Also, make sure that the domain name option in the DHCP options is configured as explained in the http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_DHCP_Options.html[Amazon VPC documentation^]. You provide your VPC settings when you launch the Quick Start.
 
 Each deployment takes about {deployment_time} to complete.
 
-[start=2]
-. Check the AWS Region that’s displayed in the upper-right corner of the navigation bar, and change it if necessary. This is where the network infrastructure for {partner-product-short-name} will be built. The template is launched in the {default_deployment_region} Region by default.
+. Sign in to your AWS account, and choose one of the following options to launch the AWS CloudFormation template. For help with choosing an option, see link:#_deployment_options[deployment options] earlier in this guide.
++
+[cols="3,1"]
+|===
+^|https://fwd.aws/nb3Px?[Deploy {partner-product-short-name} into a new VPC on AWS^]
+^|https://fwd.aws/Y3rkd?[View template^]
+^|https://fwd.aws/WVQYn?[Deploy {partner-product-short-name} into an existing VPC on AWS^]
+^|https://fwd.aws/nxrVE?[View template^]
+|===
 
-// *Note:* This deployment includes Amazon EFS, which isn’t currently supported in all AWS Regions. For a current list of supported Regions, see the https://docs.aws.amazon.com/general/latest/gr/elasticfilesystem.html[endpoints and quotas webpage].
-
-[start=3]
+. Check the AWS Region that's displayed in the upper-right corner of the navigation bar, and change it if necessary. This Region is where you build the infrastructure. The template is launched in the {default_deployment_region} Region by default. For a current list of supported Regions, see the https://docs.citrix.com/en-us/citrix-adc/13/deploying-vpx/deploy-aws/vpx-aws-support-matrix.html[VPX-AWS support matrix^] in the Citrix documentation. For more information, see link:#_supported_aws_regions[Supported AWS Regions] earlier in this guide.
 . On the *Create stack* page, keep the default setting for the template URL, and then choose *Next*.
-. On the *Specify stack details* page, change the stack name if needed. Review the parameters for the template. Provide values for the parameters that require input. For all other parameters, review the default settings and customize them as necessary.
-
-// In the following tables, parameters are listed by category and described separately for the two deployment options:
-
-// * Parameters for deploying {partner-product-short-name} into a new VPC
-// * Parameters for deploying {partner-product-short-name} into an existing VPC
+. On the *Specify stack details* page, change the stack name if needed. Review the parameters for the template. Provide values for the parameters that require input. For all other parameters, review the default settings and customize them as necessary. For details on each parameter, see the link:#_parameter_reference[Parameter reference] section of this guide. When you finish reviewing and customizing the parameters, choose *Next*.

--- a/docs/partner_editable/faq_troubleshooting.adoc
+++ b/docs/partner_editable/faq_troubleshooting.adoc
@@ -4,21 +4,25 @@
 
 *Q.* I encountered a *CREATE_FAILED* error when I launched the Quick Start.
 
-*A.* If AWS CloudFormation fails to create the stack, we recommend that you relaunch the template with *Rollback on failure* set to *Disabled*. (This setting is under *Advanced* in the AWS CloudFormation console, *Options* page.) With this setting, the stack’s state is retained and the instance is left running, so you can troubleshoot the issue. (For Windows, look at the log files in %ProgramFiles%\Amazon\EC2ConfigService and C:\cfn\log.)
-// If you’re deploying on Linux instances, provide the location for log files on Linux, or omit this sentence.
+*A.* If AWS CloudFormation fails to create the stack, relaunch the template with *Rollback on failure* set to *Disabled*. This setting is under *Advanced* in the AWS CloudFormation console on the *Configure stack options* page. With this setting, the stack’s state is retained, and the instance keeps running so that you can troubleshoot the issue. (For Windows, look at the log files in `%ProgramFiles%\Amazon\EC2ConfigService` and `C:\cfn\log`.)
+// Customize this answer if needed. For example, if you’re deploying on Linux instances, either provide the location for log files on Linux or omit the final sentence. If the Quick Start has no EC2 instances, revise accordingly (something like "and the assets keep running").
 
-WARNING: When you set *Rollback on failure* to *Disabled*, you continue to incur AWS charges for this stack. Please make sure to delete the stack when you finish troubleshooting.
+WARNING: When you set *Rollback on failure* to *Disabled*, you continue to incur AWS charges for this stack. Delete the stack when you finish troubleshooting.
 
-For additional information, see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/troubleshooting.html[Troubleshooting AWS CloudFormation^] on the AWS website.
+For more information, see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/troubleshooting.html[Troubleshooting AWS CloudFormation^].
 
-*Q.* I encountered a size limitation error when I deployed the AWS CloudFormation templates.
+//Use these three apostrophes above each new question to create a dividing line. This helps people skim for the questions relevant to them, especially as the number and length of Qs & As increases.
+'''
+*Q.* I encountered a size-limitation error when I deployed the AWS CloudFormation templates.
 
-*A.* We recommend that you launch the Quick Start templates from the links in this guide or from another S3 bucket. If you deploy the templates from a local copy on your computer or from a location other than an S3 bucket, you might encounter template size limitations. For more information about AWS CloudFormation quotas, see the http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-limits.html[AWS documentation^].
+*A.* Launch the Quick Start templates from the links in this guide or from another S3 bucket. If you deploy the templates from a local copy on your computer or from a location other than an S3 bucket, you might encounter template-size limitations. For more information, see http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-limits.html[AWS CloudFormation quotas^].
 
+'''
 *Q.* The vserver (`sample_lb_vserver`) is showing as *down*.
 
 *A.* This might be because no backend servers have been deployed. We recommend configuring service and service groups and binding them with the load-balancing virtual servers (LB vservers). For more information, see https://docs.citrix.com/en-us/netscaler/12/load-balancing/load-balancing-manage-large-scale-deployment/configure-service-groups.html[Configure service groups].
 
+'''
 *Q.* While testing in my environment, the backend servers in the remote Availability Zone show as *down*.
 
 *A.* Try one of the following options:
@@ -26,14 +30,15 @@ For additional information, see https://docs.aws.amazon.com/AWSCloudFormation/la
 * Add a static route to the remote Availability Zone server subnet by specifying the subnet IP address (SNIP) as the next hop. For more information, see https://docs.citrix.com/en-us/netscaler/12/networking/ip-routing/configuring-static-routes.html[Configuring static routes].
 * Change the subnet mask so that subnets in both Availability Zones are accommodated.
 
+'''
 *Q.* I get the error “FAIL: Could not add licenseserver.”
 
 *A.* You probably selected *Yes* when prompted, “Do you want to allocate license from ADM?” and then provided incorrect ADM/Agent IP, which is not reachable. To solve the issue, configure your management interface in such a way that you get access to the endpoints via NAT gateway and associate this NAT gateway with the management subnet (if not already done) in both the Availability Zones, or separate VPC endpoints for S3 and EC2 need to be configured.
 
+'''
 *Q.* I get this error: Failed to create resource. See the details in CloudWatch Log Stream: HTTPSConnectionPool(host=’’, port=443): Max retries exceeded with url: /nitro/v1/config/route (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at ‘’>: Failed to establish a new connection: [Errno 110] Connection timed out',))`
 
 *A.* This could be due to an existing VPC deployment when amazonaws endpoints (http://ec2.amazonaws.com/[ec2.amazonaws.com] and http://s3.amazonaws.com/[s3.amazonaws.com]) are not reachable. As a resolution, create a NAT gateway in the public subnet and thereby associate this NAT gateway with the management subnet (if not already done) in both the Availability Zones.
-
 
 
 == Additional resources


### PR DESCRIPTION
Fixed some wonkies so that the doc works with the latest boilerplate. Also reinstated the line "For a current list of supported Regions, see the VPX-AWS support matrix in the Citrix documentation." (This line is now in the deployment steps since the section on supported AWS Regions is 100% boilerplate now).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
